### PR TITLE
Import from last 12 months

### DIFF
--- a/CRM/Mailchimptemplate/Form/MailchimpTemplate.php
+++ b/CRM/Mailchimptemplate/Form/MailchimpTemplate.php
@@ -94,7 +94,7 @@ class CRM_Mailchimptemplate_Form_MailchimpTemplate extends CRM_Core_Form
             'campaigns',
             [
                 'count' => $limit,
-                'since_create_time' => date("c", strtotime("6 months ago")),
+                'since_create_time' => date("c", strtotime("-12 months")),
                 'fields' => ['settings.title'],
             ]
         );

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">http://farm.co.hu</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2021-05-12</releaseDate>
-  <version>1.0.1</version>
+  <releaseDate>2021-08-03</releaseDate>
+  <version>1.0.2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.2</ver>


### PR DESCRIPTION
Quickfix for import issue:
- user wants to import template which was created more than 6 months ago
- temporary solution is to increase this limit to 12 months (discussed with client)

Final solution could be to allow this setting to be configurable from the UI (#1)