### PR TITLE
Remove campaign limit

### DIFF
--- a/CRM/Mailchimptemplate/Form/MailchimpTemplate.php
+++ b/CRM/Mailchimptemplate/Form/MailchimpTemplate.php
@@ -118,7 +118,7 @@ class CRM_Mailchimptemplate_Form_MailchimpTemplate extends CRM_Core_Form
             'campaigns',
             [
                 'count' => $limit,
-                'since_create_time' => date("c", strtotime("-12 months")),
+                // 'since_create_time' => date("c", strtotime("-12 months")),
                 'fields' => ['settings.title'],
             ]
         );

--- a/CRM/Mailchimptemplate/Form/MailchimpTemplate.php
+++ b/CRM/Mailchimptemplate/Form/MailchimpTemplate.php
@@ -129,6 +129,7 @@ class CRM_Mailchimptemplate_Form_MailchimpTemplate extends CRM_Core_Form
                 $campaigns[$campaign['id']] = $campaign['settings']['title'];
             }
         }
+        array_multisort($campaigns);
 
         return $campaigns;
     }

--- a/CRM/Mailchimptemplate/Form/MailchimpTemplate.php
+++ b/CRM/Mailchimptemplate/Form/MailchimpTemplate.php
@@ -123,11 +123,11 @@ class CRM_Mailchimptemplate_Form_MailchimpTemplate extends CRM_Core_Form
             ]
         );
 
-        $sorted_campaigns = array_reverse($result['campaigns']);
         $campaigns = [];
-
-        foreach ($sorted_campaigns as $campaign) {
-            $campaigns[$campaign['id']] = $campaign['settings']['title'];
+        foreach ($result['campaigns'] as $campaign) {
+            if (!empty($campaign['settings']['title'])) {
+                $campaigns[$campaign['id']] = $campaign['settings']['title'];
+            }
         }
 
         return $campaigns;

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">http://farm.co.hu</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2021-08-10</releaseDate>
-  <version>1.1.0</version>
+  <releaseDate>2022-02-08</releaseDate>
+  <version>1.2.0</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.2</ver>


### PR DESCRIPTION
Changes:
- return all campaign, remove limiting by recent creation date (last 12 months)
- skip campaigns with missing title (couldn't be identified anyway)
- sort campaigns by title