### PR TITLE
Standardize tests

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -17,8 +17,8 @@
         <url desc="Support">https://github.com/reflexive-communications/hu.co.farm.mailchimptemplate/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2023-03-09</releaseDate>
-    <version>1.4.0</version>
+    <releaseDate>2023-03-16</releaseDate>
+    <version>1.5.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.47</ver>

--- a/tests/phpunit/CRM/Mailchimptemplate/Form/MailchimpTemplateSettingsTest.php
+++ b/tests/phpunit/CRM/Mailchimptemplate/Form/MailchimpTemplateSettingsTest.php
@@ -1,54 +1,14 @@
 <?php
 
-use Civi\Test;
-use CRM_Mailchimptemplate_ExtensionUtil as E;
-use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
-use Civi\Test\TransactionalInterface;
-use Civi\Test\CiviEnvBuilder;
-use PHPUnit\Framework\TestCase;
+use Civi\Mailchimptemplate\HeadlessTestCase;
 
 /**
  * Test for the settings form
  *
  * @group headless
  */
-class CRM_Mailchimptemplate_Form_MailchimpTemplateSettingsTest extends TestCase implements
-    HeadlessInterface,
-    HookInterface,
-    TransactionalInterface
+class CRM_Mailchimptemplate_Form_MailchimpTemplateSettingsTest extends HeadlessTestCase
 {
-    /**
-     * Setup used when HeadlessInterface is implemented.
-     * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
-     *
-     * @link https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
-     * @return CiviEnvBuilder
-     * @throws CRM_Extension_Exception_ParseException
-     */
-    public function setUpHeadless(): CiviEnvBuilder
-    {
-        return Test::headless()
-            ->install('rc-base')
-            ->installMe(__DIR__)
-            ->apply();
-    }
-
-    /**
-     * Apply a forced rebuild of DB, thus
-     * create a clean DB before running tests
-     *
-     * @throws CRM_Extension_Exception_ParseException
-     */
-    public static function setUpBeforeClass(): void
-    {
-        // Resets DB and install depended extension
-        Test::headless()
-            ->install('rc-base')
-            ->installMe(__DIR__)
-            ->apply(true);
-    }
-
     public function testPreProcess()
     {
         $form = new CRM_Mailchimptemplate_Form_MailchimpTemplateSettings();

--- a/tests/phpunit/CRM/Mailchimptemplate/Form/MailchimpTemplateSettingsTest.php
+++ b/tests/phpunit/CRM/Mailchimptemplate/Form/MailchimpTemplateSettingsTest.php
@@ -3,8 +3,6 @@
 use Civi\Mailchimptemplate\HeadlessTestCase;
 
 /**
- * Test for the settings form
- *
  * @group headless
  */
 class CRM_Mailchimptemplate_Form_MailchimpTemplateSettingsTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/Mailchimptemplate/SettingsTest.php
+++ b/tests/phpunit/CRM/Mailchimptemplate/SettingsTest.php
@@ -1,33 +1,12 @@
 <?php
 
-use Civi\Test;
-use PHPUnit\Framework\TestCase;
-use Civi\Test\HeadlessInterface;
+use Civi\Mailchimptemplate\HeadlessTestCase;
 
 /**
  * @group headless
  */
-class CRM_Mailchimptemplate_SettingsTest extends TestCase implements HeadlessInterface
+class CRM_Mailchimptemplate_SettingsTest extends HeadlessTestCase
 {
-    public function setUpHeadless()
-    {
-    }
-
-    /**
-     * Apply a forced rebuild of DB, thus
-     * create a clean DB before running tests
-     *
-     * @throws CRM_Extension_Exception_ParseException
-     */
-    public static function setUpBeforeClass(): void
-    {
-        // Resets DB and install depended extension
-        Test::headless()
-            ->install('rc-base')
-            ->installMe(__DIR__)
-            ->apply(true);
-    }
-
     /**
      * Tests saving and loading settings
      *

--- a/tests/phpunit/Civi/Mailchimptemplate/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/Mailchimptemplate/HeadlessTestCase.php
@@ -3,8 +3,8 @@
 namespace Civi\Mailchimptemplate;
 
 use Civi\Test;
-use PHPUnit\Framework\TestCase;
 use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group headless
@@ -19,7 +19,7 @@ class HeadlessTestCase extends TestCase implements HeadlessInterface
      */
     public static function setUpBeforeClass(): void
     {
-        // Resets DB and install depended extension
+        // Resets DB
         Test::headless()
             ->install('rc-base')
             ->installMe(__DIR__)

--- a/tests/phpunit/Civi/Mailchimptemplate/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/Mailchimptemplate/HeadlessTestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Civi\Mailchimptemplate;
+
+use Civi\Test;
+use PHPUnit\Framework\TestCase;
+use Civi\Test\HeadlessInterface;
+
+/**
+ * @group headless
+ */
+class HeadlessTestCase extends TestCase implements HeadlessInterface
+{
+    /**
+     * Apply a forced rebuild of DB, thus
+     * create a clean DB before running tests
+     *
+     * @throws \CRM_Extension_Exception_ParseException
+     */
+    public static function setUpBeforeClass(): void
+    {
+        // Resets DB and install depended extension
+        Test::headless()
+            ->install('rc-base')
+            ->installMe(__DIR__)
+            ->apply(true);
+    }
+
+    /**
+     * @return void
+     */
+    public function setUpHeadless(): void
+    {
+    }
+}


### PR DESCRIPTION
- all test inherit single `HeadlessTestCase`
- remove `tearDown`
- rename `*HeadlessTest` to `*Test`
- move `HeadlessTestCase` to `\Civi` namespace
- standardize `setUpHeadless()` docblock
- test class docblock: keep only `@group headless`
- remove unused `HookInterface`, `TransactionalInterface`; if needed add only relevant test cases
